### PR TITLE
Consolidated application.properties into application.yaml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,9 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<profiles>development</profiles>
+				</configuration>
 			</plugin>
 
 			<plugin>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.profiles.active=development

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,8 @@ redis:
 spring:
   application:
     name: ceres-routing-service
-
+  profiles:
+    active: production
 influxdb.enterprise.url: http://localhost:8086
 is.using.influxdb.enterprise: true
 number.of.databases.in.influxdb.instance: 10

--- a/src/test/java/com/rackspacecloud/metrics/tenantroutingservice/MainAppTest.java
+++ b/src/test/java/com/rackspacecloud/metrics/tenantroutingservice/MainAppTest.java
@@ -1,11 +1,13 @@
 package com.rackspacecloud.metrics.tenantroutingservice;
 
 import org.junit.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@SpringBootTest
+@ActiveProfiles("development")
 public class MainAppTest {
     @Test
     public void applicationContextTest() {
-        // There is no assert here. It's mainly to test applicationContext loading.
-        TenantRoutingServiceApplication.main(new String[] {});
     }
 }


### PR DESCRIPTION
To avoid confusion, we're consolidating onto just application.yaml in the Ceres apps and defaulting the jar's profile activation to "production".